### PR TITLE
Add Google Calendar fetch function to window.roamjs.extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,18 @@ Fetches events from the user's Google Calendar(s) for a specified date range.
 **Syntax**
 
 ```javascript
-window.roamjs.extension.google.fetchGoogleCalendar(
+window.roamjs.extension.google.fetchGoogleCalendar({
   startDatePageTitle,
-  endDatePageTitle
-);
+  endDatePageTitle,
+});
 ```
 
 **Parameters**
 
-- `startDatePageTitle` (optional) - A string representing the title of the page that corresponds to the start date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the current focused page title is used as the start date.
-- `endDatePageTitle` (optional) - A string representing the title of the page that corresponds to the end date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the start date is used as the end date.
+The function accepts a single object parameter with the following optional properties:
+
+- `startDatePageTitle` - A string representing the title of the page that corresponds to the start date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the current focused page title is used as the start date.
+- `endDatePageTitle` - A string representing the title of the page that corresponds to the end date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the start date is used as the end date.
 
 **Returns**
 
@@ -81,7 +83,10 @@ interface InputTextNode {
 
 ```javascript
 window.roamjs.extension.google
-  .fetchGoogleCalendar("January 1st, 2024", "January 31st, 2024")
+  .fetchGoogleCalendar({
+    startDatePageTitle: "January 1st, 2024",
+    endDatePageTitle: "January 31st, 2024",
+  })
   .then((events) => console.log(events))
   .catch((error) => console.error(error));
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,56 @@ If you have both this extension and SmartBlocks installed, there is a `<%GOOGLEC
 - `<%GOOGLECALENDAR:today,tomorrow%>`
 - `<%GOOGLECALENDAR:tomorrow%>`
 
+### Developer API
+
+The RoamJS Google Calendar integration offers an API to allow other extensions and custom scripts to fetch Google Calendar events directly within Roam Research. This functionality is exposed through the global `window.roamjs.extension.google` object.
+
+#### fetchGoogleCalendar
+
+**Description**
+
+Fetches events from the user's Google Calendar(s) for a specified date range.
+
+**Syntax**
+
+```javascript
+window.roamjs.extension.google.fetchGoogleCalendar(
+  startDatePageTitle,
+  endDatePageTitle
+);
+```
+
+**Parameters**
+
+- `startDatePageTitle` (optional) - A string representing the title of the page that corresponds to the start date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the current focused page title is used as the start date.
+- `endDatePageTitle` (optional) - A string representing the title of the page that corresponds to the end date of the desired events. The date should be in a format recognized by Roam's `window.roamAlphaAPI.util.pageTitleToDate` utility. If not provided, the start date is used as the end date.
+
+**Returns**
+
+A Promise that resolves to an array of `InputTextNode[]`. Each InputTextNode represents an event fetched from Google Calendar, formatted according to the user's settings. The structure of an InputTextNode is as follows:
+
+```typescript
+interface InputTextNode {
+  text: string;
+  children?: InputTextNode[];
+}
+```
+
+**Example**
+
+```javascript
+window.roamjs.extension.google
+  .fetchGoogleCalendar("January 1st, 2024", "January 31st, 2024")
+  .then((events) => console.log(events))
+  .catch((error) => console.error(error));
+```
+
+**Notes**
+
+Users must configure their Google Calendar integration through the Roam Depot settings and ensure they are authenticated for this API to return events.
+
+The function respects user settings for event filtering and formatting specified within the RoamJS Google Calendar extension settings.
+
 ### Customization
 
 All of these options are configurable from the Roam Depot page. If you used this extension when it used to hosted from RoamJS directly, there is a `Migrate Settings To Roam Depot: google-calendar` command available to migrate your old settings to the new version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "google",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "react-resizable": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Connect to various Google services to your Roam graph!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -129,12 +129,15 @@ const loadGoogleCalendar = (args: OnloadArgs) => {
           ? getPageTitleByHtmlElement(document.activeElement)?.textContent || ""
           : "";
 
-      const fetchGoogleCalendar = async (
+      const fetchGoogleCalendar = async ({
         startDatePageTitle = getActiveDatePageTitle(),
         endDatePageTitle = startDatePageTitle
           ? startDatePageTitle
-          : getActiveDatePageTitle()
-      ): Promise<InputTextNode[]> => {
+          : getActiveDatePageTitle(),
+      }: {
+        startDatePageTitle?: string;
+        endDatePageTitle?: string;
+      }): Promise<InputTextNode[]> => {
         const calendarIds = getCalendarIds();
         if (!calendarIds.length) {
           return [
@@ -271,7 +274,9 @@ const loadGoogleCalendar = (args: OnloadArgs) => {
       callback: () => {*/
         updateBlock({ text: "Loading...", uid: blockUid });
         const parentUid = getParentUidByBlockUid(blockUid);
-        fetchGoogleCalendar(getPageTitleByPageUid(parentUid))
+        fetchGoogleCalendar({
+          startDatePageTitle: getPageTitleByPageUid(parentUid),
+        })
           .then((blocks) => pushBlocks(blocks, blockUid, parentUid))
           .then(() => setTimeout(refreshEventUids, 1));
         /*  },
@@ -318,11 +323,11 @@ const loadGoogleCalendar = (args: OnloadArgs) => {
           "";
         return loadBlockUid(parentUid)
           .then((blockUid) =>
-            fetchGoogleCalendar(getPageTitleByPageUid(parentUid)).then(
-              (blocks) => {
-                pushBlocks(blocks, blockUid, getParentUidByBlockUid(blockUid));
-              }
-            )
+            fetchGoogleCalendar({
+              startDatePageTitle: getPageTitleByPageUid(parentUid),
+            }).then((blocks) => {
+              pushBlocks(blocks, blockUid, getParentUidByBlockUid(blockUid));
+            })
           )
           .then(() => setTimeout(refreshEventUids, 1));
       };
@@ -525,10 +530,13 @@ const loadGoogleCalendar = (args: OnloadArgs) => {
 
               const nlpStartDate = getNlpDate(start);
               const nlpEndDate = getNlpDate(end);
-              const startDate = dateToPageTitle(nlpStartDate);
-              const endDate = dateToPageTitle(nlpEndDate);
+              const startDatePageTitle = dateToPageTitle(nlpStartDate);
+              const endDatePageTitle = dateToPageTitle(nlpEndDate);
 
-              return fetchGoogleCalendar(startDate, endDate).then((bullets) => {
+              return fetchGoogleCalendar({
+                startDatePageTitle,
+                endDatePageTitle,
+              }).then((bullets) => {
                 setTimeout(refreshEventUids, 1000);
                 if (bullets.length) {
                   return bullets;

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -486,6 +486,9 @@ const loadGoogleCalendar = (args: OnloadArgs) => {
         return getPageTitleByBlockUid(uid) || getPageTitleByPageUid(uid);
       };
 
+      window.roamjs.extension.google = {
+        fetchGoogleCalendar,
+      };
       unloads.add(
         registerSmartBlocksCommand({
           text: "GOOGLECALENDAR",


### PR DESCRIPTION
Request from Matt V via [slack](https://roamresearch.slack.com/archives/C016N2B66JU/p1706137840152109)

> Is/could the calendar import available via the window?
I have another extension where google calendar information would be useful and I’d like to leverage your integration by calling some kind of import command and receiving a list of all the events for those days. Is that possible?