### PR TITLE
Linked Calendar layout css fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "google",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "react-resizable": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Connect to various Google services to your Roam graph!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/components/CalendarConfig.tsx
+++ b/src/components/CalendarConfig.tsx
@@ -18,14 +18,28 @@ const CalendarConfig = (props: OnloadArgs): React.ReactElement => {
   );
   return (
     <div className="flex flex-col gap-1" style={{ minWidth: 300 }}>
-      <div style={{ display: "flex" }}>
+      <div className="flex flex-col gap-2">
         <InputGroup
           value={calendar}
           onChange={(e) => setCalendar(e.target.value)}
           style={{ minWidth: "unset" }}
+          rightElement={
+            <Button
+              icon={"plus"}
+              minimal
+              disabled={!calendar}
+              onClick={() => {
+                const value = [...calendars, { calendar, account }];
+                setCalendars(value);
+                setCalendar("");
+                extensionAPI.settings.set("calendars", value);
+              }}
+            />
+          }
         />
+
         {accounts.length > 1 && (
-          <div style={{ margin: "0 4px" }}>
+          <div>
             <MenuItemSelect
               items={accounts}
               activeItem={account}
@@ -33,17 +47,6 @@ const CalendarConfig = (props: OnloadArgs): React.ReactElement => {
             />
           </div>
         )}
-        <Button
-          icon={"plus"}
-          minimal
-          disabled={!calendar}
-          onClick={() => {
-            const value = [...calendars, { calendar, account }];
-            setCalendars(value);
-            setCalendar("");
-            extensionAPI.settings.set("calendars", value);
-          }}
-        />
       </div>
       {calendars.map((p, i) => (
         <div


### PR DESCRIPTION
the `add` button is hidden behind the calendar name when multiple accounts are added

Before

![image](https://github.com/user-attachments/assets/5c0bf172-7720-4780-9706-0f80d51816c4)
 
![image](https://github.com/user-attachments/assets/d7768553-433d-47a1-b0d5-70d22f17471c)



After

![image](https://github.com/user-attachments/assets/fc405e05-4d97-47c8-9b36-aa491a3d2cb8)

![image](https://github.com/user-attachments/assets/206b2a36-31a7-499c-a16c-5bdf0d7a4bff)
